### PR TITLE
Fix typo in getAllVBucketSequenceNumbers to C++03

### DIFF
--- a/src/ep_engine.cc
+++ b/src/ep_engine.cc
@@ -5729,7 +5729,7 @@ ENGINE_ERROR_CODE EventuallyPersistentEngine::getAllVBucketSequenceNumbers(const
         if (vb) {
             vbucket_state_t state = vb->getState();
             if (state == vbucket_state_active || state == vbucket_state_replica) {
-                uint16_t vbid = htons(static_cast<uint16_t>(id));
+                uint16_t vbid = htons(static_cast<uint16_t>(*id));
                 uint64_t highSeqno;
                 if (vb->getState() == vbucket_state_active) {
                     highSeqno = htonll(vb->getHighSeqno());


### PR DESCRIPTION
Change-Id: Iabf94970bada442c3e993bdd602dc021bcb779a5
